### PR TITLE
Omitt parentheses from function name when comparing or recording

### DIFF
--- a/Sources/SnapshotTestCase.swift
+++ b/Sources/SnapshotTestCase.swift
@@ -52,14 +52,14 @@ open class SnapshotTestCase : XCTestCase {
     
     func compareSnapshot(ofView view: UIView, functionName: String = #function, file: StaticString = #file, line: UInt = #line) throws -> Bool {
         guard let snapshot = self.image(forView: view) else { throw SnapshotError.unableToTakeSnapshot }
-        let referenceImage = try self.fileManager.referenceImage(forFunctionName: functionName, options: self.options )
+        let referenceImage = try self.fileManager.referenceImage(forFunctionName: functionName.formatted(), options: self.options )
 
         return snapshot.normalizedData() == referenceImage.normalizedData()
     }
     
     func recordSnapshot(of view: UIView, functionName: String) throws {
         guard let referenceImage = self.image(forView: view) else { throw SnapshotError.unableToTakeSnapshot }
-        try self.fileManager.save(referenceImage: referenceImage, functionName: functionName, options: self.options)
+        try self.fileManager.save(referenceImage: referenceImage, functionName: functionName.formatted(), options: self.options)
     }
     
     private func image(forView view: UIView) -> UIImage? {
@@ -74,4 +74,16 @@ open class SnapshotTestCase : XCTestCase {
         return image
     }
 
+}
+
+private extension String {
+    
+    func formatted() -> String {
+        let validCharacters = CharacterSet(charactersIn: "()").inverted
+        
+        return String(self.unicodeScalars.filter { unicodeScalar -> Bool in
+            return validCharacters.contains(unicodeScalar)
+        })
+    }
+    
 }

--- a/Tests/Mocks/SnapshotFileManagerMock.swift
+++ b/Tests/Mocks/SnapshotFileManagerMock.swift
@@ -56,7 +56,7 @@ class SnapshotFileManagerMock : SnapshotFileManaging {
         self.referenceImageFunctionNameArgument = functionName
         self.referenceImageOptionsArgument = options
         if let error = self.referenceImageErrorToThrow { throw error }
-        return self.referenceImageReturnValue!
+        return self.referenceImageReturnValue ?? UIImage()
     }
     
     

--- a/Tests/SnapshotTestTests/SnapshotTestCaseTests.swift
+++ b/Tests/SnapshotTestTests/SnapshotTestCaseTests.swift
@@ -73,6 +73,17 @@ class SnapshotTestCaseTests: XCTestCase {
         // Then
         XCTAssertFalse(result)
     }
+    
+    func testCompareSnapshot_withFunctionNameContainingParentheses_shouldInvokeFileManagerWithoutParentheses() throws {
+        // Given
+        let view = self.redSquareView()
+        
+        // When
+        _ = try self.sut.compareSnapshot(ofView: view, functionName: "testWithParentheses()")
+        
+        // Then
+        XCTAssertEqual(self.fileManagerMock.referenceImageFunctionNameArgument, "testWithParentheses")
+    }
 
     // MARK: Record Snapshot
 
@@ -101,6 +112,17 @@ class SnapshotTestCaseTests: XCTestCase {
 
         // Then
         catch { XCTAssertTrue(error as! SnapshotFileManagerError == errorToThrow) }
+    }
+    
+    func testRecordSnapshot_withFunctionNameContainingParentheses_shouldInvokeFileManagerWithoutParentheses() throws {
+        // Given
+        let view = self.redSquareView()
+        
+        // When
+        try self.sut.recordSnapshot(of: view, functionName: "testWithParentheses()")
+        
+        // Then
+        XCTAssertEqual(self.fileManagerMock.saveFunctionNameArgument, "testWithParentheses")
     }
 
     private func redSquareView() -> UIView {


### PR DESCRIPTION
Relates to https://github.com/parski/SnapshotTest/issues/15