### PR TITLE
Print reference image path on record

### DIFF
--- a/Sources/SnapshotCoordinator.swift
+++ b/Sources/SnapshotCoordinator.swift
@@ -29,7 +29,7 @@ import UIKit
 
 protocol SnapshotCoordinating {
     func compareSnapshot(of snapshotable: Snapshotable, options: Options, functionName: String, line: UInt) throws
-    func recordSnapshot(of snapshotable: Snapshotable, options: Options, functionName: String, line: UInt) throws
+    func recordSnapshot(of snapshotable: Snapshotable, options: Options, functionName: String, line: UInt) throws -> URL
 }
 
 struct SnapshotCoordinator {
@@ -57,10 +57,11 @@ extension SnapshotCoordinator : SnapshotCoordinating {
             throw SnapshotError.imageMismatch(filename: filename)
         }
     }
-
-    func recordSnapshot(of snapshotable: Snapshotable, options: Options = [], functionName: String, line: UInt) throws {
+    
+    @discardableResult
+    func recordSnapshot(of snapshotable: Snapshotable, options: Options = [], functionName: String, line: UInt) throws -> URL {
         guard let referenceImage = snapshotable.snapshot() else { throw SnapshotError.unableToTakeSnapshot }
         let filename = filenameFormatter.format(functionName: functionName, options: options)
-        try fileManager.save(referenceImage: referenceImage, filename: filename, className: className)
+        return try fileManager.save(referenceImage: referenceImage, filename: filename, className: className)
     }
 }

--- a/Sources/SnapshotFileManager.swift
+++ b/Sources/SnapshotFileManager.swift
@@ -50,7 +50,7 @@ class DataHandler : DataHandling {
 }
 
 protocol SnapshotFileManaging {
-    func save(referenceImage: UIImage, filename: String, className: String) throws
+    func save(referenceImage: UIImage, filename: String, className: String) throws -> URL
     func referenceImage(filename: String, className: String) throws -> UIImage
 }
 
@@ -108,7 +108,8 @@ class SnapshotFileManager {
 
 extension SnapshotFileManager : SnapshotFileManaging {
 
-    func save(referenceImage: UIImage, filename: String, className: String) throws {
+    @discardableResult
+    func save(referenceImage: UIImage, filename: String, className: String) throws -> URL {
         guard let referenceImageDirectory = referenceImageDirectory?.appendingPathComponent(className) else { throw SnapshotFileManagerError.unableToDetermineReferenceImageDirectory }
         if fileManager.fileExists(atPath: referenceImageDirectory.absoluteString) == false {
             try fileManager.createDirectory(at: referenceImageDirectory, withIntermediateDirectories: true, attributes: nil)
@@ -117,6 +118,7 @@ extension SnapshotFileManager : SnapshotFileManaging {
         let path = try buildAbsolutePath(for: filename, className: className)
         guard let imagePngData = referenceImage.pngData() else { throw SnapshotFileManagerError.unableToSerializeReferenceImage }
         try dataHandler.write(imagePngData, to: path, options: .atomicWrite)
+        return path
     }
 
     func referenceImage(filename: String, className: String) throws -> UIImage {

--- a/Sources/SnapshotTestCase.swift
+++ b/Sources/SnapshotTestCase.swift
@@ -92,8 +92,8 @@ open class SnapshotTestCase : XCTestCase {
     }
     
     private func recordSnapshot(of snapshotable: Snapshotable, options: Options, functionName: String, file: StaticString, line: UInt) throws {
-        try coordinator.recordSnapshot(of: snapshotable, options: options, functionName: functionName, line: line)
-        XCTFail("🔴 RECORD MODE: Reference image saved.", file: file, line: line)
+        let path = try coordinator.recordSnapshot(of: snapshotable, options: options, functionName: functionName, line: line)
+        XCTFail("🔴 RECORD MODE: Reference image saved to: \(path.absoluteString)", file: file, line: line)
     }
 
 }

--- a/Sources/SnapshotTestCase.swift
+++ b/Sources/SnapshotTestCase.swift
@@ -93,7 +93,14 @@ open class SnapshotTestCase : XCTestCase {
     
     private func recordSnapshot(of snapshotable: Snapshotable, options: Options, functionName: String, file: StaticString, line: UInt) throws {
         let path = try coordinator.recordSnapshot(of: snapshotable, options: options, functionName: functionName, line: line)
-        XCTFail("🔴 RECORD MODE: Reference image saved to: \(path.absoluteString)", file: file, line: line)
+        XCTFail("🔴 RECORD MODE: Reference image saved to \(path.absoluteStringWithoutScheme)", file: file, line: line)
     }
 
+}
+
+fileprivate extension URL {
+    
+    var absoluteStringWithoutScheme: String {
+        return "/" + pathComponents.dropFirst().joined(separator: "/")
+    }
 }

--- a/Tests/Mocks/SnapshotFileManagerMock.swift
+++ b/Tests/Mocks/SnapshotFileManagerMock.swift
@@ -35,6 +35,7 @@ class SnapshotFileManagerMock : SnapshotFileManaging {
     var saveFilenameArgument: String?
     var saveClassNameArgument: String?
     var saveErrorToThrow: Error?
+    var saveReturnValue: URL?
     
     var referenceImageInvokeCount: Int = 0
     var referenceImageFilenameArgument: String?
@@ -42,12 +43,13 @@ class SnapshotFileManagerMock : SnapshotFileManaging {
     var referenceImageErrorToThrow: Error?
     var referenceImageReturnValue: UIImage?
     
-    func save(referenceImage: UIImage, filename: String, className: String) throws {
+    func save(referenceImage: UIImage, filename: String, className: String) throws -> URL {
         saveInvokeCount += 1
         saveReferenceImageArgument = referenceImage
         saveFilenameArgument = filename
         saveClassNameArgument = className
         if let error = saveErrorToThrow { throw error }
+        return saveReturnValue ?? URL(fileURLWithPath: "/")
     }
     
     func referenceImage(filename: String, className: String) throws -> UIImage {

--- a/Tests/SnapshotTestTests/SnapshotCoordinatorTests.swift
+++ b/Tests/SnapshotTestTests/SnapshotCoordinatorTests.swift
@@ -90,7 +90,6 @@ class SnapshotCoordinatorTests: XCTestCase {
     // MARK: Record Snapshot
 
     func testRecordSnapshot_withRedView_shouldSaveReferenceImageOfViewWithCorrectFilenameAndClassName() throws {
-
         // Given
         let view = redSquareView()
 
@@ -115,14 +114,29 @@ class SnapshotCoordinatorTests: XCTestCase {
             XCTAssertEqual(error as? SnapshotFileManagerError, SnapshotFileManagerError.unableToSerializeReferenceImage)
         }
     }
+    
+    func testRecordSnapshot_withFileManagerReturnsPath_shouldReturnPath() throws {
+        // Given
+        fileManagerMock.saveReturnValue = URL(fileURLWithPath: "/path/to/referenceImage.png")
+        
+        // When
+        let path = try sut.recordSnapshot(of: redSquareView(), functionName: "", line: 0)
+        
+        // Then
+        XCTAssertEqual(path, URL(fileURLWithPath: "/path/to/referenceImage.png"))
+    }
+}
 
+// MARK: - Helpers
+
+extension SnapshotCoordinatorTests {
+    
     private func redSquareView() -> UIView {
         let size = 100 / UIScreen.main.scale
         let view = UIView(frame: CGRect(x: 0, y: 0, width: size, height: size))
         view.backgroundColor = .red
         return view
     }
-    
 }
 
 class FilenameFormattingMock : FilenameFormatting {

--- a/Tests/SnapshotTestTests/SnapshotFileManagerTests.swift
+++ b/Tests/SnapshotTestTests/SnapshotFileManagerTests.swift
@@ -133,6 +133,18 @@ class SnapshotFileManagerTests: XCTestCase {
         XCTAssertEqual(dataHandlerMock.writeInvokeCount, 1)
         XCTAssertEqual(dataHandlerMock.writePathArgument, URL(fileURLWithPath: "/ReferenceImageDirectory/CustomViewTests/testFunctionName.png"))
     }
+    
+    func testSave_withReferenceImageDirectoryDoesExist_shouldReturnPathToSavedFile() throws {
+        // Given
+        processInfo.environment["REFERENCE_IMAGE_DIR"] = "/ReferenceImageDirectory"
+        fileManagerMock.fileExistsReturnValue = true
+        
+        // When
+        let path = try sut.save(referenceImage: testImage, filename: "testFunctionName", className: "CustomViewTests")
+        
+        // Then
+        XCTAssertEqual(path, URL(fileURLWithPath: "/ReferenceImageDirectory/CustomViewTests/testFunctionName.png"))
+    }
 
     // MARK: Reference Image
     


### PR DESCRIPTION
Fixes https://github.com/parski/SnapshotTest/issues/18.

Outputs record mode failures like so:
```
Test Case '-[CocoaPodsTests.CocoaPodsTests testLayerSnapshot]' started.
/Users/parski/Development/SnapshotTest/Integration/CocoaPods/CocoaPodsTests/CocoaPodsTests.swift:68: error: -[CocoaPodsTests.CocoaPodsTests testLayerSnapshot] : failed - 🔴 RECORD MODE: Reference image saved to /Users/parski/Development/SnapshotTest/Integration/CocoaPods/CocoaPodsTests/ReferenceImages/CocoaPodsTests/testLayerSnapshot.png
Test Case '-[CocoaPodsTests.CocoaPodsTests testLayerSnapshot]' failed (0.065 seconds).
```